### PR TITLE
Build nightly images to keep up with Caddy releases

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,6 +3,15 @@ name: docker
 
 on: 
   workflow_dispatch:
+    inputs:
+      publish_type:
+        description: 'What type of image the job should publish'
+        required: false
+        default: 'release'
+        type: choice
+        options:
+          - release
+          - beta
   schedule:
     - cron: '0 1 * * *'
 
@@ -36,7 +45,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       - name: Build and push release image
-        if: ${{github.event_name == 'workflow_dispatch'}}
+        if: ${{inputs.publish_type == 'release'}}
         uses: docker/build-push-action@v3
         with:
           context: .
@@ -49,7 +58,7 @@ jobs:
             ref=ghcr.io/${{ github.event.repository.owner.login }}/authp:latest"
           cache-to: type=inline
       - name: Build and push beta image
-        if: ${{github.event_name == 'schedule'}}
+        if: ${{ (github.event_name == 'schedule') || (inputs.publish_type == 'beta') }}
         uses: docker/build-push-action@v3
         with:
           context: .

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -41,7 +41,7 @@ jobs:
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
+          username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       - name: Build and push release image

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,7 +1,10 @@
 ---
 name: docker
 
-on: [workflow_dispatch]
+on: 
+  workflow_dispatch:
+  schedule:
+    - cron: '0 1 * * *'
 
 jobs:
   publish:
@@ -32,7 +35,8 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
-      - name: Build and push image
+      - name: Build and push release image
+        if: ${{github.event_name == 'workflow_dispatch'}}
         uses: docker/build-push-action@v3
         with:
           context: .
@@ -43,4 +47,16 @@ jobs:
           platforms: linux/amd64,linux/arm64
           cache-from: "type=registry,\
             ref=ghcr.io/${{ github.event.repository.owner.login }}/authp:latest"
+          cache-to: type=inline
+      - name: Build and push beta image
+        if: ${{github.event_name == 'schedule'}}
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: "ghcr.io/${{ github.event.repository.owner.login }}/authp:beta"
+          platforms: linux/amd64,linux/arm64
+          cache-from: "type=registry,\
+            ref=ghcr.io/${{ github.event.repository.owner.login }}/authp:beta"
           cache-to: type=inline

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM caddy:builder AS builder
+FROM caddy:2-builder AS builder
 
 LABEL org.opencontainers.image.title=authp
 LABEL org.opencontainers.image.description="Authentication Portal"
@@ -13,6 +13,6 @@ RUN xcaddy build \
     --with github.com/greenpau/caddy-trace@latest \
     --with github.com/caddy-dns/cloudflare
 
-FROM caddy:latest
+FROM caddy:2
 
 COPY --from=builder /usr/bin/caddy /usr/bin/caddy


### PR DESCRIPTION
Until your recent release (thank you btw!), the image was running on an older base image of Caddy. I prefer to keep Caddy on its latest version, so this PR adds a nightly (1am UTC) action job to build the image against the latest Caddy base image. This image tag is intended to be "use at your own risk", since it is built with no human interaction and could have issues with Caddy minor version updates. Ideally the plugin build would fail preventing a new image publish, however.

Summary:
- On manual job runs (on_workflow), build the release/latest image. The beta image can be built manually by setting a job input, otherwise it's scheduled for 1am UTC.
- Pin the Dockerfile versions to 2, in accordance with Caddy's recommendations and to prevent any catastrophic failure with nightly builds if Caddy 3 releases some day.
- Change the GHCR login username, since `github.actor` is the wrong username variable to use when running scheduled jobs

Considerations:
- I named the image tag `beta`, however I'm not in love with the name. If you have a better name, we can switch it (maybe `nightly` or `rolling`?)
- This hasn't been tested with a Caddy base image update, so there's a chance that the caching is too aggressive, but it's pretty unlikely IMO.